### PR TITLE
curriculum: fix link to msgpack.org

### DIFF
--- a/site/curriculum.js
+++ b/site/curriculum.js
@@ -95,7 +95,7 @@ const curriculum = [
             it can really hurt, especially if you end up serializing/deserializing
             the same data repeatedly.
             Here are a couple of benchmarks: of parsing 64K of JSON, and the
-            same data encoded in <a href="http://msgpack.org/index.html">msgpack</a> format.
+            same data encoded in <a href="//msgpack.org">msgpack</a> format.
             </p>
         `,
         'programs': {"json_parse.py": "iterations", "msgpack_parse.py": "iterations"},


### PR DESCRIPTION
- msgpack.org has a valid, trusted SSL certificate; so does GH Pages.
  If we're loaded over HTTPS, the user probably wants outbound links
  to also load over HTTPS.
- Nobody should be linking to /index.html.
