### PR TITLE
fix primes_sieve.c compilation erorr

### DIFF
--- a/benchmarks/sum.py
+++ b/benchmarks/sum.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
 def f(NUMBER):
-    s = 0
-    for i in xrange(NUMBER):
-        s += 1
+    sum(xrange(NUMBER))
 
 if __name__ == '__main__':
     import sys

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -54,7 +54,7 @@ def benchmark(prog):
 def compile(source):
     if source.endswith(".c"):
         binary = source.replace(".c", "")
-        subprocess.check_call(["gcc", "-O2", "-o", binary, source])
+        subprocess.check_call(["gcc", "-O2", "-o", binary, source, "-lm"])
     else:
         binary = source
     return source, binary


### PR DESCRIPTION
primes_sieve.c:(.text+0xad): undefined reference to `sqrt'

``` shell
:~/one-second$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/5/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.2.1-22ubuntu2' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 5.2.1 20151010 (Ubuntu 5.2.1-22ubuntu2) 
```
