### PR TITLE
Avoid laziness of StringIO.write spoiling benchmark correctness.

### DIFF
--- a/benchmarks/write_to_memory.py
+++ b/benchmarks/write_to_memory.py
@@ -14,6 +14,7 @@ def f(NUMBER):
     while bytes_written < NUMBER:
         output.write(s)
         bytes_written += CHUNK_SIZE
+    output.getvalue()  # Force StringIO to realize buffer.
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
Without `output.getvalue()` the StringIO object will just accumulate references to `s` until it hits 100,000 references, at which point the internal buffer will actually be realized. 

Currently, this benchmark can be run and do 99,999 `.write()` operations on the `StringIO` object but `99_999 * CHUNK_SIZE` bytes are **not** written into memory as a single 99GB buffer.